### PR TITLE
Fixed Demo Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | :----------------------: | :-------------------: | :---------------------: |
 | ![Screenshot][connected] | ![Screenshot][scoped] | ![Screenshot][disabled] |
 
-[demo]: https://mbaumgartenbr.github.io/flutter_tree_view/
+[demo]: https://baumths.github.io/flutter_tree_view
 [example]: https://github.com/mbaumgartenbr/flutter_tree_view/tree/main/example
 [connected]: https://raw.githubusercontent.com/mbaumgartenbr/flutter_tree_view/main/.github/assets/example_lines_connecting.png
 [scoped]: https://raw.githubusercontent.com/mbaumgartenbr/flutter_tree_view/main/.github/assets/example_lines_scoped.png


### PR DESCRIPTION
I've found that the [demo url](https://mbaumgartenbr.github.io/flutter_tree_view/) no longer exists, while the current one is https://baumths.github.io/flutter_tree_view.