### PR TITLE
Indentation Improvements

### DIFF
--- a/example/lib/src/examples.dart
+++ b/example/lib/src/examples.dart
@@ -70,9 +70,10 @@ class TreeIndentGuideScope extends StatelessWidget {
           color: Theme.of(context).colorScheme.outline,
           thickness: state.lineThickness,
           origin: state.lineOrigin,
-          roundCorners: state.roundedCorners,
           strokeCap: StrokeCap.round,
           pathModifier: state.lineStyle.toPathModifier(),
+          roundCorners: state.roundedCorners,
+          connectBranches: state.connectBranches,
         );
         break;
       case IndentType.scopingLines:

--- a/example/lib/src/examples.dart
+++ b/example/lib/src/examples.dart
@@ -71,6 +71,8 @@ class TreeIndentGuideScope extends StatelessWidget {
           thickness: state.lineThickness,
           origin: state.lineOrigin,
           roundCorners: state.roundedCorners,
+          strokeCap: StrokeCap.round,
+          pathModifier: state.lineStyle.toPathModifier(),
         );
         break;
       case IndentType.scopingLines:
@@ -79,6 +81,8 @@ class TreeIndentGuideScope extends StatelessWidget {
           color: Theme.of(context).colorScheme.outline,
           thickness: state.lineThickness,
           origin: state.lineOrigin,
+          strokeCap: StrokeCap.round,
+          pathModifier: state.lineStyle.toPathModifier(),
         );
         break;
       case IndentType.blank:

--- a/example/lib/src/settings/categories.dart
+++ b/example/lib/src/settings/categories.dart
@@ -24,6 +24,7 @@ class SettingsCategories extends StatelessWidget {
         if (indentType == IndentType.connectingLines) ...[
           const RoundedConnections(),
         ],
+        const LineStyleSelector(),
         const LineThickness(),
         const LineOrigin(),
       ],
@@ -328,6 +329,54 @@ class LineOrigin extends StatelessWidget {
       divisions: 10,
       onChanged: (value) {
         context.read<SettingsController>().updateLineOrigin(value);
+      },
+    );
+  }
+}
+
+//* Line Style -----------------------------------------------------------------
+
+class LineStyleSelector extends StatelessWidget {
+  const LineStyleSelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedLineStyle = context.select<SettingsController, LineStyle>(
+      (controller) => controller.state.lineStyle,
+    );
+
+    return ListTile(
+      title: const Text('Line Style'),
+      subtitle: Text(
+        selectedLineStyle.title,
+        style: TextStyle(
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      contentPadding: const EdgeInsetsDirectional.only(start: 16, end: 8),
+      onTap: () async {
+        final controller = context.read<SettingsController>();
+
+        final RenderBox tile = context.findRenderObject()! as RenderBox;
+        final Offset offset = tile.localToGlobal(Offset.zero);
+        final Rect(:top, :right) = offset & tile.size;
+
+        final LineStyle? newLineStyle = await showMenu<LineStyle>(
+          context: context,
+          position: RelativeRect.fromLTRB(right, top, tile.size.width, 0),
+          items: <PopupMenuEntry<LineStyle>>[
+            for (final LineStyle lineStyle in LineStyle.values)
+              PopupMenuItem(
+                value: lineStyle,
+                enabled: lineStyle != selectedLineStyle,
+                child: Text(lineStyle.title),
+              ),
+          ],
+        );
+
+        if (newLineStyle == null) return;
+        controller.updateLineStyle(newLineStyle);
       },
     );
   }

--- a/example/lib/src/settings/categories.dart
+++ b/example/lib/src/settings/categories.dart
@@ -23,6 +23,7 @@ class SettingsCategories extends StatelessWidget {
       if (indentType != IndentType.blank) ...[
         if (indentType == IndentType.connectingLines) ...[
           const RoundedConnections(),
+          const ConnectBranches(),
         ],
         const LineStyleSelector(),
         const LineThickness(),
@@ -398,6 +399,28 @@ class RoundedConnections extends StatelessWidget {
       value: roundedConnections,
       onChanged: (value) {
         context.read<SettingsController>().updateRoundedCorners(value);
+      },
+      contentPadding: const EdgeInsets.fromLTRB(16, 0, 8, 0),
+    );
+  }
+}
+
+//* Connect Branches -----------------------------------------------------------
+
+class ConnectBranches extends StatelessWidget {
+  const ConnectBranches({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final connectBranches = context.select<SettingsController, bool>(
+      (controller) => controller.state.connectBranches,
+    );
+
+    return SwitchListTile(
+      title: const Text('Connect Branches'),
+      value: connectBranches,
+      onChanged: (value) {
+        context.read<SettingsController>().updateConnectBranches(value);
       },
       contentPadding: const EdgeInsets.fromLTRB(16, 0, 8, 0),
     );

--- a/example/lib/src/settings/controller.dart
+++ b/example/lib/src/settings/controller.dart
@@ -50,6 +50,7 @@ class SettingsState {
     this.roundedCorners = false,
     this.textDirection = TextDirection.ltr,
     this.lineStyle = LineStyle.solid,
+    this.connectBranches = false,
   });
 
   final bool animateExpansions;
@@ -62,6 +63,7 @@ class SettingsState {
   final bool roundedCorners;
   final TextDirection textDirection;
   final LineStyle lineStyle;
+  final bool connectBranches;
 
   SettingsState copyWith({
     bool? animateExpansions,
@@ -74,6 +76,7 @@ class SettingsState {
     bool? roundedCorners,
     TextDirection? textDirection,
     LineStyle? lineStyle,
+    bool? connectBranches,
   }) {
     return SettingsState(
       animateExpansions: animateExpansions ?? this.animateExpansions,
@@ -86,6 +89,7 @@ class SettingsState {
       roundedCorners: roundedCorners ?? this.roundedCorners,
       textDirection: textDirection ?? this.textDirection,
       lineStyle: lineStyle ?? this.lineStyle,
+      connectBranches: connectBranches ?? this.connectBranches,
     );
   }
 }
@@ -155,5 +159,10 @@ class SettingsController with ChangeNotifier {
   void updateLineStyle(LineStyle value) {
     if (state.lineStyle == value) return;
     state = state.copyWith(lineStyle: value);
+  }
+
+  void updateConnectBranches(bool value) {
+    if (state.connectBranches == value) return;
+    state = state.copyWith(connectBranches: value);
   }
 }

--- a/example/lib/src/settings/controller.dart
+++ b/example/lib/src/settings/controller.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:path_drawing/path_drawing.dart';
 
 enum IndentType {
   connectingLines('Connecting Lines'),
@@ -14,6 +15,29 @@ enum IndentType {
   }
 }
 
+enum LineStyle {
+  dashed('Dashed'),
+  dotted('Dotted'),
+  solid('Solid');
+
+  final String title;
+  const LineStyle(this.title);
+
+  Path Function(Path)? toPathModifier() => switch (this) {
+        dashed => (Path path) => dashPath(
+              path,
+              dashArray: CircularIntervalList(const [6, 4]),
+              dashOffset: const DashOffset.absolute(6 / 4),
+            ),
+        dotted => (Path path) => dashPath(
+              path,
+              dashArray: CircularIntervalList(const [0.5, 3.5]),
+              dashOffset: const DashOffset.absolute(0.5 * 3.5),
+            ),
+        solid => null,
+      };
+}
+
 class SettingsState {
   const SettingsState({
     this.animateExpansions = true,
@@ -25,6 +49,7 @@ class SettingsState {
     this.lineThickness = 2.0,
     this.roundedCorners = false,
     this.textDirection = TextDirection.ltr,
+    this.lineStyle = LineStyle.solid,
   });
 
   final bool animateExpansions;
@@ -36,6 +61,7 @@ class SettingsState {
   final double lineThickness;
   final bool roundedCorners;
   final TextDirection textDirection;
+  final LineStyle lineStyle;
 
   SettingsState copyWith({
     bool? animateExpansions,
@@ -47,6 +73,7 @@ class SettingsState {
     double? lineThickness,
     bool? roundedCorners,
     TextDirection? textDirection,
+    LineStyle? lineStyle,
   }) {
     return SettingsState(
       animateExpansions: animateExpansions ?? this.animateExpansions,
@@ -58,6 +85,7 @@ class SettingsState {
       lineThickness: lineThickness ?? this.lineThickness,
       roundedCorners: roundedCorners ?? this.roundedCorners,
       textDirection: textDirection ?? this.textDirection,
+      lineStyle: lineStyle ?? this.lineStyle,
     );
   }
 }
@@ -122,5 +150,10 @@ class SettingsController with ChangeNotifier {
   void updateTextDirection(TextDirection value) {
     if (state.textDirection == value) return;
     state = state.copyWith(textDirection: value);
+  }
+
+  void updateLineStyle(LineStyle value) {
+    if (state.lineStyle == value) return;
+    state = state.copyWith(lineStyle: value);
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   flutter_fancy_tree_view:
     path: ../
+  path_drawing: ^1.0.1
   provider: ^6.0.5
 
 dev_dependencies:

--- a/lib/src/tree_indentation.dart
+++ b/lib/src/tree_indentation.dart
@@ -128,11 +128,13 @@ class IndentGuide {
   /// Creates an [IndentGuide].
   const IndentGuide({
     this.indent = 40.0,
+    this.padding = EdgeInsets.zero,
   }) : assert(indent >= 0.0);
 
   /// Convenient constructor to create a [ConnectingLinesGuide].
   const factory IndentGuide.connectingLines({
     double indent,
+    EdgeInsetsGeometry padding,
     Color color,
     double thickness,
     double origin,
@@ -142,6 +144,7 @@ class IndentGuide {
   /// Convenient constructor to create a [ScopingLinesGuide].
   const factory IndentGuide.scopingLines({
     double indent,
+    EdgeInsetsGeometry padding,
     Color color,
     double thickness,
     double origin,
@@ -157,6 +160,14 @@ class IndentGuide {
   /// ```
   final double indent;
 
+  /// The amount of space to inset [TreeIndentation.child].
+  ///
+  /// The indentation of tree nodes will be added to this object, i.e.,
+  /// `padding.add(EdgeInsetsDirectional.only(start: indentation))`.
+  ///
+  /// Defaults to [EdgeInsets.zero].
+  final EdgeInsetsGeometry padding;
+
   /// Method used to wrap [child] in the desired decoration/painting.
   ///
   /// Subclasses must override this method to customize whats shown inside of
@@ -166,13 +177,27 @@ class IndentGuide {
   /// * [AbstractLineGuide], an interface for working with line painting;
   Widget wrap(BuildContext context, Widget child, TreeEntry<Object> entry) {
     return Padding(
-      padding: EdgeInsetsDirectional.only(start: entry.level * indent),
+      padding: padding.add(
+        EdgeInsetsDirectional.only(start: entry.level * indent),
+      ),
       child: child,
     );
   }
 
+  /// Creates a copy of this indent guide but with the given fields replaced
+  /// with the new values.
+  IndentGuide copyWith({
+    double? indent,
+    EdgeInsetsGeometry? padding,
+  }) {
+    return IndentGuide(
+      indent: indent ?? this.indent,
+      padding: padding ?? this.padding,
+    );
+  }
+
   @override
-  int get hashCode => indent.hashCode;
+  int get hashCode => Object.hash(indent, padding);
 
   @override
   operator ==(Object other) {
@@ -180,7 +205,8 @@ class IndentGuide {
 
     return other.runtimeType == runtimeType &&
         other is IndentGuide &&
-        other.indent == indent;
+        other.indent == indent &&
+        other.padding == padding;
   }
 }
 
@@ -193,6 +219,7 @@ abstract class AbstractLineGuide extends IndentGuide {
   /// Constructor with requried parameters for building the indent line guides.
   const AbstractLineGuide({
     super.indent,
+    super.padding,
     this.color = Colors.grey,
     this.thickness = 2.0,
     this.origin = 0.5,
@@ -265,6 +292,7 @@ class ScopingLinesGuide extends AbstractLineGuide {
   /// Creates a [ScopingLinesGuide].
   const ScopingLinesGuide({
     super.indent,
+    super.padding,
     super.color,
     super.thickness,
     super.origin,
@@ -281,14 +309,17 @@ class ScopingLinesGuide extends AbstractLineGuide {
 
   /// Creates a copy of this indent guide but with the given fields replaced
   /// with the new values.
+  @override
   ScopingLinesGuide copyWith({
     double? indent,
+    EdgeInsetsGeometry? padding,
     Color? color,
     double? thickness,
     double? origin,
   }) {
     return ScopingLinesGuide(
       indent: indent ?? this.indent,
+      padding: padding ?? this.padding,
       color: color ?? this.color,
       thickness: thickness ?? this.thickness,
       origin: origin ?? this.origin,
@@ -298,6 +329,7 @@ class ScopingLinesGuide extends AbstractLineGuide {
   @override
   int get hashCode => Object.hash(
         indent,
+        padding,
         color,
         thickness,
         origin,
@@ -310,6 +342,7 @@ class ScopingLinesGuide extends AbstractLineGuide {
     return other.runtimeType == runtimeType &&
         other is ScopingLinesGuide &&
         other.indent == indent &&
+        other.padding == padding &&
         other.color == color &&
         other.thickness == thickness &&
         other.origin == origin;
@@ -365,6 +398,7 @@ class ConnectingLinesGuide extends AbstractLineGuide {
   /// Creates a [ConnectingLinesGuide].
   const ConnectingLinesGuide({
     super.indent,
+    super.padding,
     super.color,
     super.thickness,
     super.origin,
@@ -386,8 +420,10 @@ class ConnectingLinesGuide extends AbstractLineGuide {
 
   /// Creates a copy of this indent guide but with the given fields replaced
   /// with the new values.
+  @override
   ConnectingLinesGuide copyWith({
     double? indent,
+    EdgeInsetsGeometry? padding,
     Color? color,
     double? thickness,
     double? origin,
@@ -395,6 +431,7 @@ class ConnectingLinesGuide extends AbstractLineGuide {
   }) {
     return ConnectingLinesGuide(
       indent: indent ?? this.indent,
+      padding: padding ?? this.padding,
       color: color ?? this.color,
       thickness: thickness ?? this.thickness,
       origin: origin ?? this.origin,
@@ -405,6 +442,7 @@ class ConnectingLinesGuide extends AbstractLineGuide {
   @override
   int get hashCode => Object.hash(
         indent,
+        padding,
         color,
         thickness,
         origin,
@@ -418,6 +456,7 @@ class ConnectingLinesGuide extends AbstractLineGuide {
     return other.runtimeType == runtimeType &&
         other is ConnectingLinesGuide &&
         other.indent == indent &&
+        other.padding == padding &&
         other.color == color &&
         other.thickness == thickness &&
         other.origin == origin &&

--- a/lib/src/tree_indentation.dart
+++ b/lib/src/tree_indentation.dart
@@ -315,6 +315,10 @@ abstract class AbstractLineGuide extends IndentGuide {
   /// }
   /// ```
   /// > The values above should be tweaked to reach the desired result.
+  ///
+  /// Performance warning: be careful when using dashing/dotting algorithms
+  /// as they could lead to poor rendering (jank), typically when combining
+  /// large trees and animations.
   final PathModifier? pathModifier;
 
   /// Subclasses must override this method to provide the [CustomPainter] that

--- a/lib/src/tree_indentation.dart
+++ b/lib/src/tree_indentation.dart
@@ -139,6 +139,8 @@ class IndentGuide {
     double thickness,
     double origin,
     bool roundCorners,
+    StrokeCap strokeCap,
+    StrokeJoin strokeJoin,
     PathModifier? pathModifier,
   }) = ConnectingLinesGuide;
 
@@ -149,6 +151,8 @@ class IndentGuide {
     Color color,
     double thickness,
     double origin,
+    StrokeCap strokeCap,
+    StrokeJoin strokeJoin,
     PathModifier? pathModifier,
   }) = ScopingLinesGuide;
 
@@ -230,6 +234,8 @@ abstract class AbstractLineGuide extends IndentGuide {
     this.color = Colors.grey,
     this.thickness = 2.0,
     this.origin = 0.5,
+    this.strokeCap = StrokeCap.butt,
+    this.strokeJoin = StrokeJoin.miter,
     this.pathModifier,
   })  : assert(thickness >= 0.0),
         assert(
@@ -266,6 +272,16 @@ abstract class AbstractLineGuide extends IndentGuide {
   ///
   /// Used when painting to horizontally position a line on each [indent] level.
   final double originOffset;
+
+  /// The kind of finish to place on the end of lines drawn.
+  ///
+  /// Defaults to [StrokeCap.butt], i.e. no caps.
+  final StrokeCap strokeCap;
+
+  /// The kind of finish to place on the joins between line segments.
+  ///
+  /// Defaults to [StrokeJoin.miter], i.e. sharp corners.
+  final StrokeJoin strokeJoin;
 
   /// An optional mapper callback that can be used to apply some styling to tree
   /// lines like dashing and dotting.
@@ -304,10 +320,12 @@ abstract class AbstractLineGuide extends IndentGuide {
   /// will handle line painting.
   CustomPainter createPainter(BuildContext context, TreeEntry<Object> entry);
 
-  /// Creates the [Paint] object that will be used to paint lines.
+  /// Creates the [Paint] object that will be used to draw lines.
   Paint createPaint() => Paint()
     ..color = color
     ..strokeWidth = thickness
+    ..strokeCap = strokeCap
+    ..strokeJoin = strokeJoin
     ..style = PaintingStyle.stroke;
 
   /// Calculates the origin offset of the line drawn for the given [level].
@@ -337,6 +355,8 @@ class ScopingLinesGuide extends AbstractLineGuide {
     super.color,
     super.thickness,
     super.origin,
+    super.strokeCap,
+    super.strokeJoin,
     super.pathModifier,
   });
 
@@ -358,6 +378,8 @@ class ScopingLinesGuide extends AbstractLineGuide {
     Color? color,
     double? thickness,
     double? origin,
+    StrokeCap? strokeCap,
+    StrokeJoin? strokeJoin,
     PathModifier? Function()? pathModifier,
   }) {
     return ScopingLinesGuide(
@@ -366,6 +388,8 @@ class ScopingLinesGuide extends AbstractLineGuide {
       color: color ?? this.color,
       thickness: thickness ?? this.thickness,
       origin: origin ?? this.origin,
+      strokeCap: strokeCap ?? this.strokeCap,
+      strokeJoin: strokeJoin ?? this.strokeJoin,
       pathModifier: pathModifier != null ? pathModifier() : this.pathModifier,
     );
   }
@@ -377,6 +401,8 @@ class ScopingLinesGuide extends AbstractLineGuide {
         color,
         thickness,
         origin,
+        strokeCap,
+        strokeJoin,
         pathModifier,
       );
 
@@ -391,6 +417,8 @@ class ScopingLinesGuide extends AbstractLineGuide {
         other.color == color &&
         other.thickness == thickness &&
         other.origin == origin &&
+        other.strokeCap == strokeCap &&
+        other.strokeJoin == strokeJoin &&
         other.pathModifier == pathModifier;
   }
 }
@@ -451,6 +479,8 @@ class ConnectingLinesGuide extends AbstractLineGuide {
     super.color,
     super.thickness,
     super.origin,
+    super.strokeCap,
+    super.strokeJoin,
     super.pathModifier,
     this.roundCorners = false,
   });
@@ -478,6 +508,8 @@ class ConnectingLinesGuide extends AbstractLineGuide {
     double? thickness,
     double? origin,
     bool? roundCorners,
+    StrokeCap? strokeCap,
+    StrokeJoin? strokeJoin,
     PathModifier? Function()? pathModifier,
   }) {
     return ConnectingLinesGuide(
@@ -487,6 +519,8 @@ class ConnectingLinesGuide extends AbstractLineGuide {
       thickness: thickness ?? this.thickness,
       origin: origin ?? this.origin,
       roundCorners: roundCorners ?? this.roundCorners,
+      strokeCap: strokeCap ?? this.strokeCap,
+      strokeJoin: strokeJoin ?? this.strokeJoin,
       pathModifier: pathModifier != null ? pathModifier() : this.pathModifier,
     );
   }
@@ -498,6 +532,8 @@ class ConnectingLinesGuide extends AbstractLineGuide {
         color,
         thickness,
         origin,
+        strokeCap,
+        strokeJoin,
         pathModifier,
         roundCorners,
       );
@@ -513,6 +549,8 @@ class ConnectingLinesGuide extends AbstractLineGuide {
         other.color == color &&
         other.thickness == thickness &&
         other.origin == origin &&
+        other.strokeCap == strokeCap &&
+        other.strokeJoin == strokeJoin &&
         other.pathModifier == pathModifier &&
         other.roundCorners == roundCorners;
   }

--- a/lib/src/tree_indentation.dart
+++ b/lib/src/tree_indentation.dart
@@ -608,12 +608,12 @@ class _ConnectingLinesPainter extends CustomPainter {
     late double Function(int level) calculateOffset;
 
     if (textDirection == TextDirection.rtl) {
-      connectionEnd = size.width - indentation;
-      connectionStart = connectionEnd + guide.originOffset;
+      connectionStart = size.width - (indentation - guide.originOffset);
+      connectionEnd = connectionStart - guide.indent * 0.5;
       calculateOffset = (int level) => size.width - guide.offsetOfLevel(level);
     } else {
-      connectionEnd = indentation;
       connectionStart = indentation - guide.originOffset;
+      connectionEnd = connectionStart + guide.indent * 0.5;
       calculateOffset = guide.offsetOfLevel;
     }
 

--- a/lib/src/tree_indentation.dart
+++ b/lib/src/tree_indentation.dart
@@ -449,9 +449,8 @@ class _ScopingLinesPainter extends CustomPainter {
 
     for (int level = 1; level <= nodeLevel; level++) {
       final double x = calculateOffset(level);
-      path
-        ..moveTo(x, size.height)
-        ..lineTo(x, 0);
+      path.moveTo(x, size.height);
+      path.lineTo(x, 0);
     }
 
     canvas.drawPath(
@@ -589,9 +588,7 @@ class _ConnectingLinesPainter extends CustomPainter {
   final TextDirection? textDirection;
   final double indentation;
 
-  void runForEachAncestorLevelThatHasNextSibling(
-    void Function(int level) action,
-  ) {
+  void runForEachAncestorLevelThatHasNextSibling(ValueChanged<int> action) {
     TreeEntry<Object>? current = entry;
     while (current != null && current.level > 0) {
       if (current.hasNextSibling) {
@@ -603,18 +600,18 @@ class _ConnectingLinesPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    late double connectionEnd;
-    late double connectionStart;
-    late double Function(int level) calculateOffset;
+    final double Function(int level) calculateOffset;
+    double connectionEnd;
+    double connectionStart;
 
     if (textDirection == TextDirection.rtl) {
+      calculateOffset = (int level) => size.width - guide.offsetOfLevel(level);
       connectionStart = size.width - (indentation - guide.originOffset);
       connectionEnd = connectionStart - guide.indent * 0.5;
-      calculateOffset = (int level) => size.width - guide.offsetOfLevel(level);
     } else {
+      calculateOffset = guide.offsetOfLevel;
       connectionStart = indentation - guide.originOffset;
       connectionEnd = connectionStart + guide.indent * 0.5;
-      calculateOffset = guide.offsetOfLevel;
     }
 
     final Path path = Path();
@@ -622,15 +619,12 @@ class _ConnectingLinesPainter extends CustomPainter {
     // Add vertical lines
     runForEachAncestorLevelThatHasNextSibling((int level) {
       final double x = calculateOffset(level);
-      path
-        ..moveTo(x, size.height)
-        ..lineTo(x, 0);
+      path.moveTo(x, size.height);
+      path.lineTo(x, 0);
     });
 
-    // Add connection
-
+    // Add connections
     final double y = size.height * 0.5;
-
     path.moveTo(connectionStart, 0.0);
 
     if (guide.roundCorners) {
@@ -645,7 +639,6 @@ class _ConnectingLinesPainter extends CustomPainter {
       } else {
         path.lineTo(connectionStart, y);
       }
-
       path.lineTo(connectionEnd, y);
     }
 


### PR DESCRIPTION
- [x] Add a way to modify the tree lines path object before drawing on the canvas (enabling line dashing/dotting).
  > The actual line dashing algorithm was not implemented in this PR, but the demo app was updated to include a visual example of the above using the [path_drawing](https://pub.dev/packages/path_drawing) package.
- [x] `IndentGuide.padding`
  > Optional inset values added to the padding that indents tree nodes and wraps  `TreeIndentation.child`.
- [x] Add an optional `┐` shaped line to `ConnectingLinesGuide` which connects parent and descendant lines.
  > the above was pointed out in https://github.com/baumths/flutter_tree_view/issues/29#issuecomment-1321168387

Resolves #49 