### PR TITLE
Fix `collapseCascading()` in animated trees

### DIFF
--- a/lib/src/sliver_animated_tree.dart
+++ b/lib/src/sliver_animated_tree.dart
@@ -195,9 +195,18 @@ class _SliverAnimatedTreeState<T extends Object>
   List<TreeEntry<T>> _buildSubtree(TreeEntry<T> entry) {
     final List<TreeEntry<T>> subtree = <TreeEntry<T>>[];
     widget.controller.depthFirstTraversal(
-      rootEntry: entry,
-      onTraverse: subtree.add,
-    );
+        rootEntry: entry,
+        onTraverse: subtree.add,
+        descendCondition: (TreeEntry<T> entry) {
+          TreeEntry<T>? current = entry;
+          while (current != null) {
+            if (_animatingNodes.contains(current.node)) {
+              return true;
+            }
+            current = current.parent;
+          }
+          return entry.isExpanded;
+        });
     if (subtree.length > widget.maxNodesToShowWhenAnimating) {
       return subtree.sublist(0, widget.maxNodesToShowWhenAnimating);
     }

--- a/lib/src/sliver_animated_tree.dart
+++ b/lib/src/sliver_animated_tree.dart
@@ -195,18 +195,19 @@ class _SliverAnimatedTreeState<T extends Object>
   List<TreeEntry<T>> _buildSubtree(TreeEntry<T> entry) {
     final List<TreeEntry<T>> subtree = <TreeEntry<T>>[];
     widget.controller.depthFirstTraversal(
-        rootEntry: entry,
-        onTraverse: subtree.add,
-        descendCondition: (TreeEntry<T> entry) {
-          TreeEntry<T>? current = entry;
-          while (current != null) {
-            if (_animatingNodes.contains(current.node)) {
-              return true;
-            }
-            current = current.parent;
+      rootEntry: entry,
+      onTraverse: subtree.add,
+      descendCondition: (TreeEntry<T> entry) {
+        TreeEntry<T>? current = entry;
+        while (current != null) {
+          if (_animatingNodes.contains(current.node)) {
+            return true;
           }
-          return entry.isExpanded;
-        });
+          current = current.parent;
+        }
+        return entry.isExpanded;
+      },
+    );
     if (subtree.length > widget.maxNodesToShowWhenAnimating) {
       return subtree.sublist(0, widget.maxNodesToShowWhenAnimating);
     }


### PR DESCRIPTION
Previously when `TreeController.collapseCascading()` was called, any listening `AnimatingTreeView`s only animated the nodes present in the iterable that was given to `collapseCascading`, all other nodes vanished immediately.
This PR fixes #41 by making sure we check a given node's ancestors for animating nodes when building the flat subtree that will animate out. 