### PR TITLE
Fix: example build error

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,6 +7,8 @@ import 'src/examples.dart' show SelectedExampleNotifier;
 import 'src/settings/controller.dart' show SettingsController;
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
   final prefs = await SharedPreferences.getInstance();
   runApp(
     MultiProvider(

--- a/example/lib/src/examples/filterable.dart
+++ b/example/lib/src/examples/filterable.dart
@@ -1,4 +1,4 @@
-import 'package:faker/faker.dart';
+import 'package:faker/faker.dart' as faker;
 import 'package:flutter/material.dart';
 import 'package:flutter_fancy_tree_view/flutter_fancy_tree_view.dart';
 
@@ -256,7 +256,7 @@ class _TreeTileState extends State<TreeTile> {
   }
 }
 
-final lorem = Faker().lorem;
+final lorem = faker.Faker().lorem;
 void populateExampleTree(Node node, [int level = 0]) {
   if (level >= 7) return;
   node.children.addAll([


### PR DESCRIPTION
Hi,

I've tried to build the example for an android emulator with Flutter 3.24.3 and I got a build error and a runtime exception. These changes fix both problems. The errors were the following:

```
lib/src/examples/filterable.dart:219:64: Error: A value of type 'Color/*1*/' can't be assigned to a variable of type 'Color/*2*/'.
 - 'Color/*1*/' is from 'dart:ui'.
 - 'Color/*2*/' is from 'package:faker/src/colors.dart' ('../../../.pub-cache/hosted/pub.dev/faker-2.2.0/lib/src/colors.dart').
    final Color highlightColor = Theme.of(context).colorScheme.primary;
                                                               ^
lib/src/examples/filterable.dart:221:14: Error: The argument type 'Color/*1*/' can't be assigned to the parameter type 'Color/*2*/?'.
 - 'Color/*1*/' is from 'package:faker/src/colors.dart' ('../../../.pub-cache/hosted/pub.dev/faker-2.2.0/lib/src/colors.dart').
 - 'Color/*2*/' is from 'dart:ui'.
      color: highlightColor,
             ^
lib/src/examples/filterable.dart:222:24: Error: The argument type 'Color/*1*/' can't be assigned to the parameter type 'Color/*2*/?'.
 - 'Color/*1*/' is from 'package:faker/src/colors.dart' ('../../../.pub-cache/hosted/pub.dev/faker-2.2.0/lib/src/colors.dart').
 - 'Color/*2*/' is from 'dart:ui'.
      decorationColor: highlightColor,
                       ^
Target kernel_snapshot_program failed: Exception


FAILURE: Build failed with an exception.
```

```
E/flutter ( 7240): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Binding has not yet been initialized.                                  
E/flutter ( 7240): The "instance" getter on the ServicesBinding binding mixin is only available once that binding has been initialized.                           
E/flutter ( 7240): Typically, this is done by calling "WidgetsFlutterBinding.ensureInitialized()" or "runApp()" (the latter calls the former). Typically this call is done in the "void main()" method. The "ensureInitialized" method is idempotent; calling it multiple times is not harmful. After calling that method, the "instance" getter will return the binding.                                                                                                                             
E/flutter ( 7240): In a test, one can call "TestWidgetsFlutterBinding.ensureInitialized()" as the first line in the test's "main()" method to initialize the binding.
```